### PR TITLE
Allow init tab complete currently installed boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ This is a module and completion script for [myzsh](https://github.com/brimstone/
 ## Usage
 
 * `vagrant <tab>`
+* `vagrant init <tab>` will show you currently added boxes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # myzsh-vagrant
 
-This is a module and completion script for [myzsh](https://github.com/brimstone/myzsh).
+This is a module and completion script for [myzsh](https://github.com/myzsh/myzsh).
 
 ## Requirements
 

--- a/completions/_vagrant
+++ b/completions/_vagrant
@@ -59,3 +59,5 @@ _vagrant () {
 }
 
 _vagrant "$@"
+
+# vim: filetype=zsh noexpandtab

--- a/completions/_vagrant
+++ b/completions/_vagrant
@@ -16,11 +16,9 @@ _vagrant () {
 	}
 	getboxes() {
         	local -a boxes
-	        if [ "$2" = "init" ]; then
-        	    boxes=(
-                	$(print -l $(basename ~/.vagrant.d/boxes/*(/)))
+        	boxes=(
+               		$(print -l $(basename ~/.vagrant.d/boxes/*(/)))
             	)
-        	fi
 	        _describe -t commands "vagrant init $2" boxes -V1
 	}
 	local -a verbs

--- a/completions/_vagrant
+++ b/completions/_vagrant
@@ -19,7 +19,7 @@ _vagrant () {
         	boxes=(
 			$(vagrant box list | cut -d " " -f 1)
             	)
-	        _describe -t commands "vagrant init $2" boxes -V1
+	        _describe -t commands "vagrant init" boxes -V1
 	}
 	local -a verbs
 	IFS=$'\n'
@@ -41,7 +41,7 @@ _vagrant () {
 		getvms "" up
 	;;
 	init) # Initialize new Vagrant host
-		getboxes "" init
+		getboxes
 	;;
 	# FIXME this could be done better, fixing [LPRIMARY,LSECONDARY,...] files ...
 	*)

--- a/completions/_vagrant
+++ b/completions/_vagrant
@@ -14,6 +14,15 @@ _vagrant () {
 		fi
 		_describe -t commands "vagrant $1" vms -V1
 	}
+	getboxes() {
+        	local -a boxes
+	        if [ "$2" = "init" ]; then
+        	    boxes=(
+                	$(print -l $(basename ~/.vagrant.d/boxes/*(/)))
+            	)
+        	fi
+	        _describe -t commands "vagrant init $2" boxes -V1
+	}
 	local -a verbs
 	IFS=$'\n'
 	# words[2] is whatever is already typed into the command line after "myzsh "
@@ -34,7 +43,7 @@ _vagrant () {
 		getvms "" up
 	;;
 	init) # Initialize new Vagrant host
-		getvms "" init
+		getboxes "" init
 	;;
 	# FIXME this could be done better, fixing [LPRIMARY,LSECONDARY,...] files ...
 	*)

--- a/completions/_vagrant
+++ b/completions/_vagrant
@@ -17,7 +17,7 @@ _vagrant () {
 	getboxes() {
         	local -a boxes
         	boxes=(
-			$(print -l $(basename ~/.vagrant.d/boxes/*(/)))
+			$(vagrant box list | cut -d " " -f 1)
             	)
 	        _describe -t commands "vagrant init $2" boxes -V1
 	}

--- a/completions/_vagrant
+++ b/completions/_vagrant
@@ -17,7 +17,7 @@ _vagrant () {
 	getboxes() {
         	local -a boxes
         	boxes=(
-               		$(print -l $(basename ~/.vagrant.d/boxes/*(/)))
+			$(print -l $(basename ~/.vagrant.d/boxes/*(/)))
             	)
 	        _describe -t commands "vagrant init $2" boxes -V1
 	}

--- a/modules/vagrant/vagrant
+++ b/modules/vagrant/vagrant
@@ -1,2 +1,4 @@
 
 compdef _vagrant vagrant
+
+# vim: filetype=zsh noexpandtab


### PR DESCRIPTION
Usage:

vagrant `<tab>` -> select init `<tab>` -> user show list of boxes they currently have added based on contents of ~/.vagrant.d/boxes

If there is a better way of listing the folders in ~/.vagrant.d/boxes than `print -l $(basename ~/.vagrant.d/boxes/*(/))` I'm open to suggestions.
